### PR TITLE
Fix filtering of characters

### DIFF
--- a/src/novels/annotators/CharacterAnnotator.java
+++ b/src/novels/annotators/CharacterAnnotator.java
@@ -102,9 +102,14 @@ public class CharacterAnnotator {
 
 				// if one character's name is a complete subset of another's,
 				// don't add it (e.g., Joe > Mr. Joe Gargery)
-				if (!name.equals(name2) && name2Set.containsAll(nameSet)) {
+				if (!nameSet.equals(name2Set) && name2Set.containsAll(nameSet)) {
 					flag = true;
-					continue;
+				}
+				// if there are namesets that are equal (e.g. "Sakura Kinomoto"
+				// and "Kinomoto Sakura") then only add the name first in
+				// lexicographic order
+				if (nameSet.equals(name2Set) && name.compareTo(name2) > 0) {
+				    flag = true;
 				}
 			}
 


### PR DESCRIPTION
Right now if BookNLP finds character names such as "Sakura Kinomoto" and "Kinomoto Sakura" it flags both both "Sakura Kinomoto" and "Kinomoto Sakura" because they are subsets of each other, so the character ends up not being added at all.  I made a fix to add the character name with earliest lexicographic order in that case.

I think that the getVariants method still has to be modified to include both of them though.  Because "Kinomoto Sakura" is the name that will end up getting ended, but "Sakura Kinomoto" isn't found in the getVariants part.