### PR TITLE
Quote attributions to Character Ids

### DIFF
--- a/src/novels/BookNLP.java
+++ b/src/novels/BookNLP.java
@@ -66,6 +66,8 @@ public class BookNLP {
 		CoreferenceAnnotator coref = new CoreferenceAnnotator();
 		coref.readWeights(weights);
 		coref.resolvePronouns(book);
+		
+		SyntaxAnnotator.setCharacterIds(book);	
 	}
 
 	public void dumpForAnnotation(Book book, File outputDirectory, String prefix) {
@@ -94,6 +96,7 @@ public class BookNLP {
 
 		CommandLine cmd = null;
 		try {
+
 			CommandLineParser parser = new BasicParser();
 			cmd = parser.parse(options, args);
 		} catch (Exception e) {
@@ -153,7 +156,8 @@ public class BookNLP {
 		}
 
 		Book book = new Book(tokens);
-
+		
+		
 		if (cmd.hasOption("w")) {
 			bookNLP.weights = cmd.getOptionValue("w");
 			System.out.println(String.format("Using coref weights: ",
@@ -166,10 +170,12 @@ public class BookNLP {
 		book.id = prefix;
 		bookNLP.process(book, directory, prefix);
 
+		
 		if (cmd.hasOption("printHTML")) {
 			File htmlOutfile = new File(directory, prefix + ".html");
 			PrintUtil.printWithLinksAndCorefAndQuotes(htmlOutfile, book);
 		}
+
 
 		if (cmd.hasOption("d")) {
 			System.out.println("Dumping for annotation");

--- a/src/novels/annotators/SyntaxAnnotator.java
+++ b/src/novels/annotators/SyntaxAnnotator.java
@@ -107,6 +107,20 @@ public class SyntaxAnnotator {
 		}
 		return null;
 	}
+	
+	public static void setCharacterIds(Book book)
+	{
+		try{
+			for (Token anno : book.tokens) {
+					if (book.tokenToCharacter.containsKey(anno.tokenId)) {
+						anno.characterId=book.tokenToCharacter.get(anno.tokenId).getCharacterId();
+					}
+				}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
 
 	public static String getMods(Book book, int index) {
 		Token token = book.tokens.get(index);
@@ -340,7 +354,9 @@ public class SyntaxAnnotator {
 					p++;
 				}
 			}
-			s++;
+			s++; // 
+			
+			
 			DependencyStructure graph = service.parse(parseTokens);
 			SymbolTable symboltable = graph.getSymbolTables().getSymbolTable(
 					"DEPREL");

--- a/src/novels/annotators/SyntaxAnnotator.java
+++ b/src/novels/annotators/SyntaxAnnotator.java
@@ -354,7 +354,7 @@ public class SyntaxAnnotator {
 					p++;
 				}
 			}
-			s++; // 
+			s++; 
 			
 			
 			DependencyStructure graph = service.parse(parseTokens);

--- a/src/novels/util/PrintUtil.java
+++ b/src/novels/util/PrintUtil.java
@@ -162,6 +162,7 @@ public class PrintUtil {
 
 	}
 
+	
 	public void printWithLinks(String infile, String outFile, Book book) {
 		OutputStreamWriter out = null;
 		try {
@@ -244,13 +245,17 @@ public class PrintUtil {
 			out = new OutputStreamWriter(new FileOutputStream(outFile), "UTF-8");
 			for (Quotation quote : book.quotations) {
 				String guessString = "";
+				int characterId = -1;
+				
 				if (quote.attributionId != 0) {
 					Token token = book.tokens.get(quote.attributionId);
-					guessString = token.word;
+					guessString = token.word;					
+					characterId = token.characterId;
 				}
-				out.write(String.format("%s\t%s\t%s\t%s\t%s\t%s\n", book.id,
-						quote.start, quote.end, 0, quote.attributionId,
-						guessString));
+				out.write(String.format("%s\t%s\t%s\t%d\t%s\t%s\t%s\t%d\n", book.id,
+						quote.start, quote.end, quote.sentenceId, 0, quote.attributionId,
+						guessString, characterId));
+
 			}
 
 			out.close();
@@ -271,7 +276,7 @@ public class PrintUtil {
 				if (token.coref != 0) {
 					out.write(i + "\t");
 					Token head = book.tokens.get(token.coref);
-					out.write(String.format("%s\t%s", token.coref, head.word));
+					out.write(String.format("%s\t%d\t%s", token.coref, head.characterId, head.word));
 					out.write("\n");
 				} 
 
@@ -279,7 +284,7 @@ public class PrintUtil {
 //				for (Integer c : cands.get(i)) {
 //					out.write(c + " ");
 //				}
-
+//				out.write("\n");
 			}
 			out.close();
 

--- a/src/novels/util/PrintUtil.java
+++ b/src/novels/util/PrintUtil.java
@@ -47,9 +47,9 @@ public class PrintUtil {
 			out = new OutputStreamWriter(new FileOutputStream(outFile), "UTF-8");
 			out.write(Token.ORDER + "\n");
 			for (Token anno : book.tokens) {
-				if (book.tokenToCharacter.containsKey(anno.tokenId)) {
-					anno.characterId=book.tokenToCharacter.get(anno.tokenId).getCharacterId();
-				}
+	//			if (book.tokenToCharacter.containsKey(anno.tokenId)) {
+	//				anno.characterId=book.tokenToCharacter.get(anno.tokenId).getCharacterId();
+	//			}
 				out.write(anno + "\n");
 			}
 			out.close();


### PR DESCRIPTION
Created a function that assigns character Ids beforehand in the BookNLP process() function, rather than at the end during printing.

For the option "d", In printQuotes, added two extra attributes, sentenceID and characterId to be attributed to each quote and printed to file. This quickly widens the scope of quote Attribution to a large extent, as every 'he' and 'she' that a quote is attributed to is mapped to their character Ids, making it possible to see which character actually said which quote by a hugely increased amount.